### PR TITLE
Making more general to OrbitDB

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -60,24 +60,8 @@ const argv = yargs
   .example('$0 -r -g values-.*-baseline', 'Run all of the values baseline benchmarks')
   .argv
 
-// const rimraf = (path) => {
-//   if (fs.existsSync(path)) {
-//     fs.readdirSync(path).forEach((file, index) => {
-//       const curPath = `${path}/${file}`
-//       if (fs.lstatSync(curPath).isDirectory()) {
-//         rimraf(curPath)
-//       } else {
-//         fs.unlinkSync(curPath)
-//       }
-//     })
-//     fs.rmdirSync(path)
-//   }
-// }
-
-
 // Was this called directly from the CLI?
 // For mocha tests - maybe we can mitigate this but for now it works
 if (require.main == module) {
   start(benchmarks, argv)
-  // rimraf('./ipfs-log-benchmarks')
 }

--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ const { start } = require('./index')
 
 const yargs = require('yargs')
 const argv = yargs
-  .usage('IPFS Log benchmark runner\n\nUsage: node --expose-gc $0 [options]')
+  .usage('OrbitDB benchmark runner\n\nUsage: node --expose-gc $0 [options]')
   .version(false)
   .help('help').alias('help', 'h')
   .options({


### PR DESCRIPTION
This PR:

- Changes IPFS Log to OrbitDB in the Usage message
- Removes rimraf to prepare for other types of output