### PR TITLE
Moving global.gc to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "benchmark-runner": "./src/cli.js"
   },
   "scripts": {
-    "test": "nyc mocha --expose-gc"
+    "test": "nyc mocha"
   },
   "author": "mistakia",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-const gc = require('expose-gc/function')
-gc()
-
 /* global process */
 const { start } = require('./index')
 
@@ -61,7 +58,7 @@ const argv = yargs
 
 // Was this called directly from the CLI?
 // For mocha tests - maybe we can mitigate this but for now it works
-if (require.main == module) {
+if (require.main === module) {
   try {
     const benchmarks = require(process.cwd() + '/benchmarks')
     start(benchmarks, argv)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
-const fs = require('fs')
-const os = require('os')
+require('expose-gc')
+global.gc()
 
+const os = require('os')
 
 const report = require('./report')
 
@@ -24,10 +25,6 @@ const start = async (benchmarks, argv) => {
 
   process.stdout.write(`Running ${baselineOnly ? 'baseline ' : ''}benchmarks matching: ${grep}`)
   process.stdout.write('\n')
-
-  if (!global.gc) {
-    console.warn('start with --expose-gc')
-  }
 
   try {
     for (const benchmark of benchmarks) {

--- a/test/benchmarks/console-log.js
+++ b/test/benchmarks/console-log.js
@@ -2,7 +2,7 @@ const base = {
   prepare: async function () {
   },
   cycle: async function () {
-    const date = new Date()
+    const date = new Date() // eslint-disable-line
   },
   teardown: async function () {
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -137,9 +137,7 @@ describe('CLI Test', () => {
     it('should show help msg when arg not passed to grep', async () => {
       const yargsCmd = yargs.command(cli)
       const output = await new Promise((resolve) => {
-        yargsCmd.parse('cli -g', (err, argv, output) => {
-          if (err) { }
-
+        yargsCmd.parse('cli -g', (_, argv, output) => {
           resolve(output)
         })
       })
@@ -176,9 +174,7 @@ describe('CLI Test', () => {
     it('should show help msg when arg not passed to stressLimit', async () => {
       const yargsCmd = yargs.command(cli)
       const output = await new Promise((resolve) => {
-        yargsCmd.parse('cli --stressLimit', (err, argv, output) => {
-          if (err) { }
-
+        yargsCmd.parse('cli --stressLimit', (_, argv, output) => {
           resolve(output)
         })
       })
@@ -215,9 +211,7 @@ describe('CLI Test', () => {
     it('should show help msg when arg not passed to baselineLimit', async () => {
       const yargsCmd = yargs.command(cli)
       const output = await new Promise((resolve) => {
-        yargsCmd.parse('cli --baselineLimit', (err, argv, output) => {
-          if (err) { }
-
+        yargsCmd.parse('cli --baselineLimit', (_, argv, output) => {
           resolve(output)
         })
       })
@@ -254,9 +248,7 @@ describe('CLI Test', () => {
     it('should show help msg when arg not passed to logLimit', async () => {
       const yargsCmd = yargs.command(cli)
       const output = await new Promise((resolve) => {
-        yargsCmd.parse('cli --logLimit', (err, argv, output) => {
-          if (err) { }
-
+        yargsCmd.parse('cli --logLimit', (_, argv, output) => {
           resolve(output)
         })
       })


### PR DESCRIPTION
This PR obviates the need for `--expose-gc` flag by moving `global.gc` to index.js