### PR TITLE
import global; remove unknown gc

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-const gc = require('expose-gc/function')
-gc()
+require('expose-gc')
 
 /* global process */
 const os = require('os')


### PR DESCRIPTION
this fixes https://github.com/orbitdb/benchmark-runner/issues/16 by importing the [gc](https://www.npmjs.com/package/expose-gc) function to global. 
also removes an unknown gc call.